### PR TITLE
Fixed compute_inverse_transformation() to update self.proj_view_inv

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -149,7 +149,11 @@ impl<N: RealField> Image<N> {
 	///
 	/// Returns `true` on success.
 	pub fn compute_inverse_transformation(&mut self) -> bool {
-		self.proj_view_mat.try_inverse_mut()
+		let inv = self.proj_view_mat.try_inverse();
+		if let Some(mat) = inv {
+			self.proj_view_inv = mat;
+		}
+		inv.is_some()
 	}
 	/// Clamps position in screen space wrt its maximum in screen space.
 	pub fn clamp_pos_wrt_max(pos: &Point2<N>, max: &Point2<N>) -> Point2<N> {


### PR DESCRIPTION
`compute_inverse_transformation()` function is supposed to update `self.proj_view_inv`, but it doesn't.

I'll provide some context. We use `Trackball` camera from `kiss3d-trackball` crate. `Camera` trait from `kiss3d` provides `unproject()` function, which calls `inverse_transformation()`. For our surprise, `inverse_transformation()` implementation in `Trackball` struct always returns zero matrix. This matrix is multiplied by a point and obviously results in zero point. Finally, `Point3::from_homogenous()` tries to divide by zero, which crashes our program at the very first frame.

Our fix doesn't solve the camera issues completely. Although `unproject()` works now, but there's some flickering while rotating the camera. Sometimes extensive camera rotation leads to panic, which is caused by `h_unprojected_begin` & `h_unprojected_end` inside `unproject()` function having zero last coordinate, leading again to division by zero inside `Point3::from_homogeneous()`